### PR TITLE
Fix  cleanup inventory ts issues

### DIFF
--- a/pages/inventory.vue
+++ b/pages/inventory.vue
@@ -99,7 +99,7 @@ onMounted(() => {
       :class="locationBg">
       <button
         type="button"
-        @click="refresh"
+        @click="refresh()"
         aria-label="Refresh inventory"
         class="m-auto p-2 rounded-full bg-zinc-600 s-14 text-2xl leading-none absolute top-2 right-2 focus:bg-emerald-700 active:bg-emerald-700 focus:outline-none focus:ring focus:ring-emerald-300">
         <img

--- a/pages/inventory.vue
+++ b/pages/inventory.vue
@@ -93,7 +93,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div v-if="data.inventory !== null">
+  <div v-if="data">
     <section
       class="flex flex-col rounded-lg p-6 justify-center items-center align gap-2 bg-gradient-to-b to-zinc-950 relative"
       :class="locationBg">
@@ -144,7 +144,7 @@ onMounted(() => {
         :bottomText="`Rarity ${data.inventory.items[0].rarity}`" />
     </section>
 
-    <section class="my-4" v-if="data">
+    <section class="my-4">
       <ol v-if="data.inventory.items.length > 0" class="grid grid-cols-2 sm:grid-cols-3 gap-3" v-auto-animate>
         <InventoryItem
           v-for="item in data.inventory.items"

--- a/pages/inventory.vue
+++ b/pages/inventory.vue
@@ -93,7 +93,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div v-if="data">
+  <div v-if="data?.inventory">
     <section
       class="flex flex-col rounded-lg p-6 justify-center items-center align gap-2 bg-gradient-to-b to-zinc-950 relative"
       :class="locationBg">


### PR DESCRIPTION

## Resolves the issue for the button click event

The following is observed

```ts
Type '(opts?: AsyncDataExecuteOptions | undefined) => Promise<void>' is not assignable to type '(payload: MouseEvent) => void'
```

Reason being:
When using ```@click="refresh"``` It expects refresh to be a function that takes a MouseEvent as its argument.

Using the following ```@click="refresh()"```
calls refresh immediately and assigns the return value to the click handler. This effectively bypasses the type mismatch

## Clean up redundant v-if check
Removed ```v-if="data"``` on a sibling as the parent is already performing this check.

## Handle data' is possibly 'null'.

Changed  ```<div v-if="data.inventory !== null">``` to ```<div v-if="data?.inventory">```  to handle '__VLS_ctx.data' is possibly 'null'.

@whitep4nth3r  Do we need to check for null explicitly or will a truthy check be suffice? Im not sure how the data is set in the backend? 


closes #19