### PR TITLE
Remove decimal from 'days ago'

### DIFF
--- a/pages/inventory.vue
+++ b/pages/inventory.vue
@@ -102,7 +102,7 @@ const spawnDaysAgo = computed(() => {
     return "Yesterday";
   }
 
-  return `${diff} days ago`;
+  return `${Math.trunc(diff)} days ago`;
 });
 
 onMounted(() => {


### PR DESCRIPTION
Removed the decimal part of 'days ago' so instead of showing '196.04166666666666 days ago' it will show '196 days ago'